### PR TITLE
Improve keyword seeding and synonym UX

### DIFF
--- a/src/components/GeneratorForm.jsx
+++ b/src/components/GeneratorForm.jsx
@@ -20,6 +20,13 @@ const GeneratorForm = ({
   synonymsCache,
   handleUnitChange,
 }) => {
+  let loadedKeywordCount = 0;
+  for (const keyword of keywords) {
+    if (Object.prototype.hasOwnProperty.call(synonymsCache, keyword)) {
+      loadedKeywordCount += 1;
+    }
+  }
+
   return (
     <div className="rounded-tl-md rounded-tr-md bg-base-300 shadow-xl mx-auto max-w-2xl">
       <div className="card-body p-6 md:p-8">
@@ -192,9 +199,7 @@ const GeneratorForm = ({
                   Fetching synonyms...
                 </span>
               ) : (
-                `Synonyms loaded for ${
-                  Object.keys(synonymsCache).length
-                } keyword(s)`
+                `Synonyms loaded for ${loadedKeywordCount} keyword(s)`
               )}
             </div>
           )}

--- a/src/components/GeneratorResult.jsx
+++ b/src/components/GeneratorResult.jsx
@@ -34,7 +34,11 @@ const GeneratorResult = ({ ipsumText, unit }) => {
 
     switch (unit) {
       case "words": {
-        return `Words: ${ipsumText.split(/\s+/).length}`;
+        const normalized = ipsumText.trim();
+        const tokens = normalized
+          ? normalized.split(/\s+/).filter(Boolean)
+          : [];
+        return `Words: ${tokens.length}`;
       }
       case "sentences": {
         return `Sentences: ${ipsumText.split(/[.!?]+/).filter(Boolean).length}`;

--- a/src/components/hooks/useSynonymFetcher.js
+++ b/src/components/hooks/useSynonymFetcher.js
@@ -11,6 +11,31 @@ const RATE_LIMIT = {
   MIN_REQUEST_INTERVAL_MS: 100, // Minimum time between requests
 };
 
+const fetchWithTimeout = async (resource, options = {}, timeoutMs = 5000) => {
+  if (
+    typeof AbortSignal !== "undefined" &&
+    typeof AbortSignal.timeout === "function"
+  ) {
+    return fetch(resource, {
+      ...options,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  }
+
+  if (typeof AbortController === "undefined") {
+    return fetch(resource, options);
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(resource, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
 const useSynonymFetcher = () => {
   const [synonymsCache, setSynonymsCache] = useState({});
   const [isLoadingSynonyms, setIsLoadingSynonyms] = useState(false);
@@ -74,11 +99,10 @@ const useSynonymFetcher = () => {
               requestTimestamps.current.push(now);
               lastRequestTime.current = now;
 
-              const response = await fetch(
+              const response = await fetchWithTimeout(
                 `${apiBaseUrl}/words?rel_syn=${encodeURIComponent(keyword)}`,
-                {
-                  signal: AbortSignal.timeout(5000), // 5 second timeout
-                },
+                {},
+                5000,
               );
 
               if (!response.ok) {

--- a/src/utils/generatorLogic.js
+++ b/src/utils/generatorLogic.js
@@ -87,6 +87,23 @@ function fastRandom() {
   return (seed >>> 0) / 0x1_00_00_00_00; // Convert to float in [0, 1)
 }
 
+const computeSeedFromKeywords = (keywords) => {
+  const FNV_OFFSET = 0x81_1c_9d_c5;
+  const FNV_PRIME = 0x01_00_01_93;
+
+  let hash = FNV_OFFSET;
+
+  for (const word of keywords) {
+    for (const symbol of word) {
+      hash ^= symbol.codePointAt(0);
+      hash = Math.imul(hash, FNV_PRIME) >>> 0;
+    }
+    hash = Math.imul(hash ^ 0x9e_37_79_b9, FNV_PRIME) >>> 0;
+  }
+
+  return hash || FNV_OFFSET;
+};
+
 /**
  * Get a random integer between min and max (inclusive)
  */
@@ -130,13 +147,7 @@ const generateIpsum = (
   options = { startWithLorem: true, keywordProbability: 0.3 },
 ) => {
   // Reset seed for deterministic results with the same input
-  seed =
-    keywords.length > 0
-      ? keywords.reduce(
-          (accumulator, word) => accumulator + word.codePointAt(0),
-          0,
-        )
-      : Date.now();
+  seed = keywords.length > 0 ? computeSeedFromKeywords(keywords) : Date.now();
 
   // Pre-calculate word selection probabilities
   const {

--- a/src/utils/generatorLogic.test.js
+++ b/src/utils/generatorLogic.test.js
@@ -64,4 +64,25 @@ describe("generateIpsum", () => {
     expect(paragraphs[0].startsWith("Lorem")).toBe(true);
     expect(paragraphs[1].startsWith("Lorem")).toBe(false);
   });
+
+  it("produces repeatable output for the same keywords", () => {
+    const options = { startWithLorem: false, keywordProbability: 0.4 };
+    const firstRun = generateIpsum(["apple", "banana"], 10, "words", options);
+    const secondRun = generateIpsum(["apple", "banana"], 10, "words", options);
+
+    expect(firstRun).toBe(secondRun);
+  });
+
+  it("changes the output when keywords differ", () => {
+    const options = { startWithLorem: false, keywordProbability: 0.4 };
+    const appleIpsum = generateIpsum(["apple", "banana"], 50, "words", options);
+    const apricotIpsum = generateIpsum(
+      ["apricot", "banana"],
+      50,
+      "words",
+      options,
+    );
+
+    expect(appleIpsum).not.toBe(apricotIpsum);
+  });
 });


### PR DESCRIPTION
## Summary
- derive the ipsum generator seed from full keyword content to avoid collisions and add regression tests
- fix the result word counter and synonym status badge to reflect the displayed data accurately
- replace AbortSignal.timeout usage with a cross-browser timeout helper for synonym fetching

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_69019c881978832987ed98bdd239877c